### PR TITLE
hydraJob: make meta optional

### DIFF
--- a/customisation.nix
+++ b/customisation.nix
@@ -472,8 +472,9 @@ rec {
       outputs = drv.outputs or [ "out" ];
 
       commonAttrs = {
-        inherit (drv) name system meta;
+        inherit (drv) name system;
         inherit outputs;
+        meta = drv.meta or { };
       }
       // optionalAttrs (drv._hydraAggregate or false) {
         _hydraAggregate = true;


### PR DESCRIPTION
Although this is usually filled populated, that's not always the case. Make this easier on the generated and downstream code bases to use `hydaJob`.