### PR TITLE
filterAttrs: check if it exists on builtins

### DIFF
--- a/attrsets.nix
+++ b/attrsets.nix
@@ -660,7 +660,11 @@ rec {
 
     :::
   */
-  filterAttrs = pred: set: removeAttrs set (filter (name: !pred name set.${name}) (attrNames set));
+  filterAttrs =
+    if builtins ? filterAttrs then
+      builtins.filterAttrs
+    else
+      pred: set: removeAttrs set (filter (name: !pred name set.${name}) (attrNames set));
 
   /**
     Filter an attribute set recursively by removing all attributes for


### PR DESCRIPTION
Support for usage of more efficient builtin from https://github.com/DeterminateSystems/nix-src/pull/291.